### PR TITLE
Clarify survey dip convention

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrillHoles"
 uuid = "9d36f3b5-8124-4f7e-bcda-df733105c718"
 authors = ["Rafael Caixeta and contributors"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/compositing.jl
+++ b/src/compositing.jl
@@ -47,7 +47,7 @@ function composite(dhf::DrillHole; interval::Number=1.0, zone=nothing,
     # check gaps, holes and zones to create/separate different groups
     t1 = (dh[i-1,to] - dh[i,from]) > gap
     t2 = dh[i-1,bh] != dh[i,bh]
-    t3 = zone == nothing ? false : dh[i-1,zone] != dh[i,zone]
+    t3 = isnothing(zone) ? false : !isequal(dh[i-1,zone], dh[i,zone])
     (t1 || t2 || t3) && (c += 1)
     push!(gps,c)
   end

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -21,12 +21,15 @@ Base.show(io::IO, tb::Collar) = print(io, "Collar")
 Base.show(io::IO, ::MIME"text/plain", tb::Collar) = print(io, "Collar object")
 
 """
-    Survey(file, holeid=:HOLEID, at=:AT, azm=:AZM ,dip=:DIP, invertdip=false)
+    Survey(file, holeid=:HOLEID, at=:AT, azm=:AZM ,dip=:DIP,
+	convention=:auto, method=:mincurv)
 
 The definition of the drill hole survey table and its main column fields.
 `file` can be a `String` filepath or an already loaded `AbstractDataFrame`.
-Negative dip points downwards (or upwards if `invertdip`=true). Available methods
-for desurvey are `:mincurv` (minimum curvature/spherical arc) and `:tangential`.
+Dip `convention` can be `:auto`, `:positivedownwards` or `:negativedownwards`.
+The default is set to `:auto` and assumes that the most common dip sign points
+downwards. Available methods for desurvey are `:mincurv` (minimum curvature/
+spherical arc) and `:tangential`.
 """
 struct Survey
 	file::Union{String,AbstractDataFrame}
@@ -34,13 +37,14 @@ struct Survey
 	at::Union{String,Symbol}
 	azm::Union{String,Symbol}
 	dip::Union{String,Symbol}
-	invertdip::Bool
+	convention::Symbol
 	method::Symbol
 
 	function Survey(; file, holeid=:HOLEID, at=:AT, azm=:AZM, dip=:DIP,
-	  invertdip=false, method=:mincurv)
+	  convention=:auto, method=:mincurv)
 	  @assert method ∈ [:mincurv, :tangential] "invalid method; choose :mincurv or :tangential"
-	  new(file, holeid, at, azm, dip, invertdip, method)
+	  @assert convention ∈ [:auto, :negativedownwards, :positivedownwards] "invalid convention; choose :auto, :negativedownwards or :positivedownwards"
+	  new(file, holeid, at, azm, dip, convention, method)
 	end
 end
 

--- a/src/desurvey.jl
+++ b/src/desurvey.jl
@@ -38,8 +38,9 @@ function getcolnames(s,i)
 		c  = sum(sign.(df[!,s.dip])) > 0 ? :positivedownwards : :negativedownwards
 	end
 
+	inv  = (c == :positivedownwards)
 	pars = (holeid=s.holeid, at=s.at, azm=s.azm, dip=s.dip, from=f,
-	       to=t, invdip=(c == :positivedownwards), tang=m)
+	       to=t, invdip=inv, tang=m)
 end
 
 function gettrace(c, s)

--- a/src/desurvey.jl
+++ b/src/desurvey.jl
@@ -30,9 +30,16 @@ function getcolnames(s,i)
 	f = i isa Interval ? i.from : i[1].from
 	t = i isa Interval ? i.to   : i[1].to
 	m = s.method == :tangential
+	c = s.convention
 
-	pars = (holeid=s.holeid, at=s.at, azm=s.azm, dip=s.dip, from=f, to=t, tang=m)
-	## check duplicate names and inform (maybe also if there is a preexisting x y z length)
+	# get most common dip sign and assume it is downwards
+	if c == :auto
+		df = s.file isa String ? CSV.read(s.file, DataFrame) : s.file
+		c  = sum(sign.(df[!,s.dip])) > 0 ? :positivedownwards : :negativedownwards
+	end
+
+	pars = (holeid=s.holeid, at=s.at, azm=s.azm, dip=s.dip, from=f,
+	       to=t, invdip=(c == :positivedownwards), tang=m)
 end
 
 function gettrace(c, s)
@@ -50,9 +57,6 @@ function gettrace(c, s)
 		force_float = !(eltype(collar[!,k]) <: Float64)
 		force_float && (collar[!, k] = convert.(Float64, collar[:, k]))
 	end
-
-	# invert dip sign if requested
-	s.invertdip && (survey[!,s.dip] *= -1)
 
 	# merge collar coordinates to initial survey point
 	collar[!,s.at] .= 0.0
@@ -122,6 +126,7 @@ end
 function fillxyz!(trace, pars)
 	# get column names
 	at, az, dp, tang = pars.at, pars.azm, pars.dip, pars.tang
+	f = pars.invdip ? -1 : 1
 
 	# loop trace file
 	for i in 1:size(trace,1)
@@ -130,8 +135,8 @@ function fillxyz!(trace, pars)
 
 		# get distances and angles; return increments dx,dy,dz
 		d12      = trace[i,at] - trace[i-1,at]
-        az1, dp1 = trace[i-1,az], trace[i-1,dp]
-        az2, dp2 = trace[i,az], trace[i,dp]
+        az1, dp1 = trace[i-1,az], f*trace[i-1,dp]
+        az2, dp2 = trace[i,az], f*trace[i,dp]
         dx,dy,dz = tang ? tangential(az1,dp1,d12) : mincurv(az1,dp1,az2,dp2,d12)
 
 		# add increments dx,dy,dz to previous coordinates
@@ -146,6 +151,7 @@ function fillxyz!(tab, trace, pars)
 	# get column names
 	bh, at, az, dp, tang = pars.holeid, pars.at, pars.azm, pars.dip, pars.tang
 	from, to = pars.from, pars.to
+	f = pars.invdip ? -1 : 1
 
 	# initialize coordinate columns with float values
 	tab[!,:X] .= -9999.9999
@@ -178,8 +184,8 @@ function fillxyz!(tab, trace, pars)
 		else
 			# if not, calculate coordinates increments dx,dy,dz
 			d12 = dht[b[2],at]-dht[b[1],at]
-			az1, dp1 = dht[b[1],az], dht[b[1],dp]
-			az2, dp2 = dht[b[2],az], dht[b[2],dp]
+			az1, dp1 = dht[b[1],az], f*dht[b[1],dp]
+			az2, dp2 = dht[b[2],az], f*dht[b[2],dp]
 			azx, dpx = b[1]==b[2] ? (az2, dp2) : weightedangs([az1,dp1],[az2,dp2],d12,d1x)
 			dx,dy,dz = tang ? tangential(az1,dp1,d1x) : mincurv(az1,dp1,azx,dpx,d1x)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,9 +5,10 @@ using Test
 @testset "DrillHoles.jl" begin
     # dummy data
     collar = Collar(file=DataFrame(HOLEID=1:2, X=1:2, Y=1:2, Z=1:2))
-    survey = Survey(file=DataFrame(HOLEID=[1,1,2,2], AT=[0,5,0,5], AZM=[0,1,20,21], DIP=[89,88,77,76]))
     assays = Interval(file=DataFrame(HOLEID=[1,1,2], FROM=[1,3.5,0], TO=[3.5,8,7], A=[1,2,3]))
     lithos = Interval(file=DataFrame(HOLEID=[1,2,2], FROM=[0,0,4.4], TO=[8,4.4,8], L=["A","B","C"]))
+    survey = Survey(file=DataFrame(HOLEID=[1,1,2,2], AT=[0,5,0,5], AZM=[0,1,20,21], DIP=[89,88,77,76]),
+                    method=:mincurv, convention=:negativedownwards)
 
     # drill hole desurvey tests
     dh  = drillhole(collar, survey, [assays, lithos])
@@ -52,5 +53,57 @@ using Test
     @test all(round.(tab[!,:X], digits=1) .≈ [1,1,1,1,1,1,1,1,2,2.1,2.2,2.3,2.4,2.5,2.6,2.6])
     @test all(round.(tab[!,:Y], digits=1) .≈ [1,1,1.1,1.1,1.1,1.1,1.2,1.2,2.1,2.4,2.6,2.8,3.1,3.3,3.5,3.7])
     @test all(round.(tab[!,:Z], digits=1) .≈ [1.5,2.5,3.5,4.5,5.5,6.5,7.5,8.5,2.5,3.6,4.7,5.7,6.7,7.6,8.5,9.3])
+    @test all(isequal.(round.(tab[!,:A], digits=1), [missing,1,1,1.5,2,2,2,2,3,3,3,3,3,3,3,missing]))
+
+    ##########################################################################
+
+    # tests using different survey method and dip convention
+    survey = Survey(file=DataFrame(HOLEID=[1,1,2,2], AT=[0,5,0,5], AZM=[0,1,20,21], DIP=[89,88,77,76]),
+                    method=:tangential, convention=:auto)
+
+    # drill hole desurvey tests
+    dh  = drillhole(collar, survey, [assays, lithos])
+    tab = dh.table
+
+    @test dh.pars.invdip == true
+    @test size(tab, 1) == 6
+    @test size(tab, 2) == 9
+    @test all(isapprox.(tab[!,:HOLEID], [1.0, 1.0, 1.0, 2.0, 2.0, 2.0]))
+    @test all(isapprox.(tab[!,:FROM],   [0.0, 1.0, 3.5, 0.0, 4.4, 7.0]))
+    @test all(isapprox.(tab[!,:TO],     [1.0, 3.5, 8.0, 4.4, 7.0, 8.0]))
+    @test all(isequal.(tab[!,:L],       ["A", "A", "A", "B", "C", "C"]))
+    @test all(isequal.(tab[!,:A],       [missing, 1, 2, 3, 3, missing]))
+    @test all(round.(tab[!,:X], digits=1) .≈ [1.0, 1.0, 1.0, 2.2, 2.4, 2.6])
+    @test all(round.(tab[!,:Y], digits=1) .≈ [1.0, 1.0, 1.1, 2.5, 3.2, 3.6])
+    @test all(round.(tab[!,:Z], digits=1) .≈ [0.5,-1.2,-4.7,-0.1,-3.6,-5.3])
+
+    # drill hole :equalcomp compositing tests
+    comp1 = composite(dh; zone=:L, mode=:equalcomp)
+    tab   = comp1.table
+
+    @test size(tab, 1) == 16
+    @test size(tab, 2) == 9
+    @test all(isapprox.(tab[!,:HOLEID], [1,1,1,1,1,1,1,1,2,2,2,2,2,2,2,2]))
+    @test all(isapprox.(tab[!,:FROM],   [0,1,2,3,4,5,6,7,0,1,2,3,4.4,5.4,6.4,7.4]))
+    @test all(isapprox.(tab[!,:TO],     [1,2,3,4,5,6,7,8,1,2,3,4,5.4,6.4,7.4,8]))
+    @test all(isequal.(tab[!,:L],       ["A","A","A","A","A","A","A","A","B","B","B","B","C","C","C","C"]))
+    @test all(round.(tab[!,:X], digits=1) .≈ [1,1,1,1,1,1,1,1,2,2.1,2.2,2.3,2.4,2.5,2.5,2.6])
+    @test all(round.(tab[!,:Y], digits=1) .≈ [1,1,1,1.1,1.1,1.1,1.1,1.2,2.1,2.3,2.5,2.7,3,3.3,3.5,3.7])
+    @test all(round.(tab[!,:Z], digits=1) .≈ [0.5,-0.5,-1.5,-2.5,-3.5,-4.5,-5.5,-6.5,1.5,0.5,-0.4,-1.4,-2.8,-3.7,-4.7,-5.5])
+    @test all(isequal.(round.(tab[!,:A], digits=1), [missing,1,1,1.5,2,2,2,2,3,3,3,3,3,3,3,missing]))
+
+    # drill hole :nodiscard compositing tests
+    comp2 = composite(dh; zone=:L, mode=:nodiscard)
+    tab   = comp2.table
+
+    @test size(tab, 1) == 16
+    @test size(tab, 2) == 9
+    @test all(isapprox.(tab[!,:HOLEID], [1,1,1,1,1,1,1,1,2,2,2,2,2,2,2,2]))
+    @test all(isapprox.(tab[!,:FROM],   [0,1,2,3,4,5,6,7,0,1.1,2.2,3.3,4.4,5.3,6.2,7.1]))
+    @test all(isapprox.(tab[!,:TO],     [1,2,3,4,5,6,7,8,1.1,2.2,3.3,4.4,5.3,6.2,7.1,8]))
+    @test all(isequal.(tab[!,:L],       ["A","A","A","A","A","A","A","A","B","B","B","B","C","C","C","C"]))
+    @test all(round.(tab[!,:X], digits=1) .≈ [1,1,1,1,1,1,1,1,2,2.1,2.2,2.3,2.4,2.4,2.5,2.6])
+    @test all(round.(tab[!,:Y], digits=1) .≈ [1,1,1,1.1,1.1,1.1,1.1,1.2,2.1,2.3,2.6,2.8,3,3.2,3.4,3.6])
+    @test all(round.(tab[!,:Z], digits=1) .≈ [0.5,-0.5,-1.5,-2.5,-3.5,-4.5,-5.5,-6.5,1.5,0.4,-0.7,-1.8,-2.7,-3.6,-4.5,-5.3])
     @test all(isequal.(round.(tab[!,:A], digits=1), [missing,1,1,1.5,2,2,2,2,3,3,3,3,3,3,3,missing]))
 end


### PR DESCRIPTION
This relates to #10
Changes `invertdip` keyword to `convention`
Possible inputs are `:auto` (default), `:negativedownwards`, `:positivedownwards`
The `:auto` assumes that the most common dip sign points downwards
Moreover, the `dh.trace` dip sign is now preserved as in the input file